### PR TITLE
Make fortran 2018 compliant

### DIFF
--- a/src/CheckConvergence.f90
+++ b/src/CheckConvergence.f90
@@ -178,7 +178,7 @@ subroutine CheckConvergence
             end do
 
             ! Normalize this quantity by the number of particles per mole:
-            dResidual = dResidual / DFLOAT(iParticlesPerMole(i))
+            dResidual = dResidual / iParticlesPerMole(i)
                                 
             ! Compute absolute quantity of the residual term:
             dResidual = DABS(dResidual - dChemicalPotential(i))
@@ -251,7 +251,7 @@ subroutine CheckConvergence
         do l = 1, nSolnPhases
             k = -iAssemblage(nElements - l + 1)                 ! Absolute solution phase index.
             do i = nSpeciesPhase(k-1) + 1, nSpeciesPhase(k)     ! Absolute solution species index.
-                dResidual = dResidual + dMolesSpecies(i) * dStoichSpecies(i,j) / DFLOAT(iParticlesPerMole(i))        
+                dResidual = dResidual + dMolesSpecies(i) * dStoichSpecies(i,j) / iParticlesPerMole(i)
             end do
         end do
         

--- a/src/CheckMiscibilityGap.f90
+++ b/src/CheckMiscibilityGap.f90
@@ -67,7 +67,7 @@ subroutine CheckMiscibilityGap(iSolnPhaseIndex,lAddPhase)
     iLast            = nSpeciesPhase(iSolnPhaseIndex)          
     nConstituents    = iLast - iFirst + 1                      
     dMinMoleFraction = 1D-3
-    dMaxMoleFraction = 1D0 - dMinMoleFraction * DFLOAT(nConstituents-1)
+    dMaxMoleFraction = 1D0 - dMinMoleFraction * (nConstituents-1)
     dMaxMoleFraction = DMAX1(dMaxMoleFraction, 0.9D0)
     lAddPhase        = .FALSE.
 

--- a/src/CheckPureConPhaseRem.f90
+++ b/src/CheckPureConPhaseRem.f90
@@ -115,7 +115,7 @@ subroutine CheckPureConPhaseRem
                 exit LOOP_PureConPhases
             
             end if
-                                                                                                                                                                                                                 
+
             ! Try removing this pure condensed phase from the phase assemblage:
             call RemPureConPhase(iPhaseChange,lSwapLater,lPhasePass)
                                                                                                                           

--- a/src/CheckSolnPhaseAdd.f90
+++ b/src/CheckSolnPhaseAdd.f90
@@ -123,7 +123,7 @@ subroutine CheckSolnPhaseAdd
          !   (nConPhases + nSolnPhases < nElements - nChargedConstraints)) then
         IF_SolnPhaseAdd: if ((dDrivingForceSoln(i) < dTolerance(4)).AND. & 
             (nConPhases + nSolnPhases < nElements)) then
-                                                                                                                                                                  
+
             ! Try adding this solution phase to the assemblage:
             call AddSolnPhase(i,lSwapLater,lPhasePass)
                       

--- a/src/CheckSystemExcess.f90
+++ b/src/CheckSystemExcess.f90
@@ -201,7 +201,7 @@ subroutine CheckSystemExcess
 
                                 if (l <= n) then
                                     ! l is the constituent index on sublattice m.   
-                                                                                                                                          
+
                                     if (iConstituentPass(iPhaseSublatticeCS(i),m,l) == 0) then
 
                                         ! If any of the constituents associated with this parameter did not pass, then

--- a/src/CompExcessGibbsEnergyRKMP.f90
+++ b/src/CompExcessGibbsEnergyRKMP.f90
@@ -138,16 +138,16 @@ subroutine CompExcessGibbsEnergyRKMP(iSolnIndex)
                     if (j == iRegularParam(iParam,2)) then
                         ! First species of parameter.                        
                         dPartialExcessGibbs(i) = dPartialExcessGibbs(i) + dExcessGibbsParam(iParam) * &
-                            dxvmo * ((x2 - xprod)*dx + DFLOAT(iExponent)*xprod*(1D0 - dx))
+                            dxvmo * ((x2 - xprod)*dx + (iExponent)*xprod*(1D0 - dx))
 
                     elseif (j == iRegularParam(iParam,3)) then
                         ! Second species of parameter.                       
                         dPartialExcessGibbs(i) = dPartialExcessGibbs(i) + dExcessGibbsParam(iParam) * &
-                            dxvmo * ((x1 - xprod)*dx - DFLOAT(iExponent)*xprod*(1D0 + dx))     
+                            dxvmo * ((x1 - xprod)*dx - (iExponent)*xprod*(1D0 + dx))     
                     else 
                         ! This species does not belong to the parameter.
                         dPartialExcessGibbs(i) = dPartialExcessGibbs(i) - dExcessGibbsParam(iParam) * &
-                            (dx**(iExponent)) * xprod * (1D0 + DFLOAT(iExponent)) 
+                            (dx**(iExponent)) * xprod * (1D0 + iExponent)
                     end if    
                                                                                         
                 end do

--- a/src/CompExcessGibbsEnergySUBL.f90
+++ b/src/CompExcessGibbsEnergySUBL.f90
@@ -222,7 +222,7 @@ subroutine CompExcessGibbsEnergySUBL(iSolnIndex)
                 n = j - iFirst + 1
                 
                 ! Compute pre-factor term:
-                dTemp = 1D0 - DFLOAT(nSublattice)
+                dTemp = 1D0 - nSublattice
                 
                 ! Loop through sublattices:
                 do s = 1, nSublattice
@@ -303,7 +303,7 @@ subroutine CompExcessGibbsEnergySUBL(iSolnIndex)
                 ! Reinitialize variables:
                 KD    = 0 
                 m     = i - iFirst + 1
-                dTemp = -DFLOAT(nSublattice + iRegularParam(l,n+2)) 
+                dTemp = -(nSublattice + iRegularParam(l,n+2))
                 
                 ! Loop through sublattices associated with this phase:
                 LOOP_Param_Sub: do s = 1, nSublattice
@@ -345,7 +345,7 @@ subroutine CompExcessGibbsEnergySUBL(iSolnIndex)
                 
                 ! Apply higher order terms (only if dFirstParam and dSecondParam are not the same):
                 if (dFirstParam /= dSecondParam) then
-                    dTemp = dTemp + DFLOAT(KD * iRegularParam(l,n+2)) / (dFirstParam - dSecondParam)
+                    dTemp = dTemp + (KD * iRegularParam(l,n+2)) / (dFirstParam - dSecondParam)
                 end if
 
                 ! Apply partial molar excess Gibbs energy of mixing:

--- a/src/CompFunctionNorm.f90
+++ b/src/CompFunctionNorm.f90
@@ -87,7 +87,7 @@ subroutine CompFunctionNorm
             end do
             
             ! Normalize the residual term by the number of particles per formula mass:
-            dTemp = dTemp / DFLOAT(iParticlesPerMole(i))
+            dTemp = dTemp / iParticlesPerMole(i)
             
             ! Compute the residual term weighted by the mole fraction:
             dTemp = DABS(dChemicalPotential(i) - dTemp) * dMolFraction(i)

--- a/src/CompFunctionNorm.f90
+++ b/src/CompFunctionNorm.f90
@@ -74,7 +74,7 @@ subroutine CompFunctionNorm
         dGEMFunctionNorm = dGEMFunctionNorm + (dTemp)**(2)
 
     end do
-	           
+
     ! Compute the residuals of the Gibbs energy difference between each solution phase and the element potentials:
     do l = 1, nSolnPhases
         k      = -iAssemblage(nElements - l + 1)       ! Absolute solution phase index
@@ -89,12 +89,12 @@ subroutine CompFunctionNorm
             ! Normalize the residual term by the number of particles per formula mass:
             dTemp = dTemp / DFLOAT(iParticlesPerMole(i))
             
-			! Compute the residual term weighted by the mole fraction:
+            ! Compute the residual term weighted by the mole fraction:
             dTemp = DABS(dChemicalPotential(i) - dTemp) * dMolFraction(i)
                                                                                       
             ! Exclude trace species from the computation of the functional norm:
             dTempB = dTempB + dTemp
-					
+
         end do
 
         dGEMFunctionNorm = dGEMFunctionNorm + (dTempB)**(2)
@@ -114,12 +114,12 @@ subroutine CompFunctionNorm
         dGEMFunctionNorm = dGEMFunctionNorm + (dTemp)**(2)
 
     end do
-	
+
     ! Finally, the functional norm:
     dGEMFunctionNorm = dGEMFunctionNorm**(0.5)
 
     if (lDebugMode .EQV. .TRUE.) print *, 'dGEMFunctionNorm = ', dGEMFunctionNorm
-    
+
     return
-    
+
 end subroutine CompFunctionNorm

--- a/src/CompMolFraction.f90
+++ b/src/CompMolFraction.f90
@@ -132,7 +132,7 @@ subroutine CompMolFraction(k)
                 do j = 1, nElements
                     dTemp = dTemp + dElementPotential(j) * dStoichSpecies(i,j)
                 end do
-                dTemp           = dTemp / DFLOAT(iParticlesPerMole(i))
+                dTemp           = dTemp / iParticlesPerMole(i)
                 dMolFraction(i) = DEXP(dTemp - dStdGibbsEnergy(i))
                 dMolFraction(i) = DMIN1(dMolFraction(i),1D0)
             end do
@@ -146,7 +146,7 @@ subroutine CompMolFraction(k)
         dSumMolFractionSoln(k) = dSumMolFractionSoln(k) + dMolFraction(i)            
         do j = 1,nElements
             dEffStoichSolnPhase(k,j) = dEffStoichSolnPhase(k,j) + dMolFraction(i) * &
-                dStoichSpecies(i,j) / DFLOAT(iParticlesPerMole(i))
+                dStoichSpecies(i,j) / iParticlesPerMole(i)
         end do
     end do
                         

--- a/src/CompStoichSolnPhase.f90
+++ b/src/CompStoichSolnPhase.f90
@@ -60,7 +60,7 @@ subroutine CompStoichSolnPhase(k)
     
         LOOP_B: do j = 1,nElements
             dEffStoichSolnPhase(k,j) = dEffStoichSolnPhase(k,j) + dMolFraction(i) * dStoichSpecies(i,j) &
-                / DFLOAT(iParticlesPerMole(i))
+                / iParticlesPerMole(i)
             
             ! Check for a NAN:
             if (dEffStoichSolnPhase(k,j) /= dEffStoichSolnPhase(k,j)) then

--- a/src/CompThermoData.f90
+++ b/src/CompThermoData.f90
@@ -190,7 +190,7 @@ subroutine CompThermoData
         end if
          
         ! Convert chemical potentials to dimensionless units:
-        dChemicalPotential(j) = dChemicalPotential(j) * dTemp * DFLOAT(iParticlesPerMoleCS(i))
+        dChemicalPotential(j) = dChemicalPotential(j) * dTemp * iParticlesPerMoleCS(i)
                                                                             
         ! Add pressure dependence term to the chemical potential term:
         if (iPhaseCS(i) == 1) then
@@ -395,7 +395,7 @@ subroutine CompThermoData
 
     ! Store the standard molar Gibbs energies:
     do i = 1, nSpecies
-        dStdGibbsEnergy(i) = dChemicalPotential(i) * dSpeciesTotalAtoms(i) / DFLOAT(iParticlesPerMole(i))
+        dStdGibbsEnergy(i) = dChemicalPotential(i) * dSpeciesTotalAtoms(i) / iParticlesPerMole(i)
     end do
 
     ! Store an integer vector representing the component index when the phase is ionic.

--- a/src/CorrectMolFraction.f90
+++ b/src/CorrectMolFraction.f90
@@ -95,7 +95,7 @@ subroutine CorrectMolFraction
             end do
 
             ! Normalize this quantity by the number of particles per mole:
-            dTemp = dTemp / DFLOAT(iParticlesPerMole(i))
+            dTemp = dTemp / iParticlesPerMole(i)
 
             ! Compute correction factor to mole fraction:
             dTemp = dTemp - dChemicalPotential(i)

--- a/src/GEMLineSearch.f90
+++ b/src/GEMLineSearch.f90
@@ -330,7 +330,7 @@ subroutine InitGEMLineSearch(dStepLength,dMolesSpeciesLast,dElementPotentialLast
                 dTemp = dTemp + dUpdateVar(j) * dStoichSpecies(i,j)
             end do
             
-            dTemp = dTemp / DFLOAT(iParticlesPerMole(i))
+            dTemp = dTemp / iParticlesPerMole(i)
             
             ! NOTE: The variable dMolFraction is used temporarily to represent 
             ! the fractional update to dMolesSpecies, but it does not replace

--- a/src/GEMLineSearch.f90
+++ b/src/GEMLineSearch.f90
@@ -381,7 +381,7 @@ subroutine InitGEMLineSearch(dStepLength,dMolesSpeciesLast,dElementPotentialLast
         end if
     end do
 
-	! Update the element potentials:
+    ! Update the element potentials:
     do i = 1, nElements
         dElementPotential(i) = dUpdateVar(i)
     end do

--- a/src/GEMNewton.f90
+++ b/src/GEMNewton.f90
@@ -127,7 +127,7 @@ subroutine GEMNewton(INFO)
                 ! Loop through species in phase:   
                 do l = nSpeciesPhase(m-1) + 1, nSpeciesPhase(m)
                     dTemp  = dStoichSpecies(l,i) * dStoichSpecies(l,j) * dMolesSpecies(l)
-                    A(i,j) = A(i,j) + dTemp / (DFLOAT(iParticlesPerMole(l))**2)
+                    A(i,j) = A(i,j) + dTemp / (iParticlesPerMole(l)**2)
                 end do
             end do
             ! Apply symmetry:
@@ -142,7 +142,7 @@ subroutine GEMNewton(INFO)
             k = -iAssemblage(nElements - l + 1)
             do i = nSpeciesPhase(k-1) + 1, nSpeciesPhase(k)
                 dTemp = dStoichSpecies(i,j) * dMolesSpecies(i) * (dChemicalPotential(i) - 1D0)
-                B(j)  = B(j) + dTemp / DFLOAT(iParticlesPerMole(i))
+                B(j)  = B(j) + dTemp / iParticlesPerMole(i)
             end do
         end do   
     end do

--- a/src/GetFirstAssemblage.f90
+++ b/src/GetFirstAssemblage.f90
@@ -78,7 +78,7 @@ subroutine GetFirstAssemblage
     
     dTempArr = 0D0
     do i = 1,nSpecies
-        dTempArr(i,1:nElements) = dChemicalPotential(i) * DFLOAT(iAtomFractionSpecies(i,1:nElements))
+        dTempArr(i,1:nElements) = dChemicalPotential(i) * iAtomFractionSpecies(i,1:nElements)
     end do
     
     ! The following integer vector contains the indices of species with the 

--- a/src/GetOutputSiteFraction.f90
+++ b/src/GetOutputSiteFraction.f90
@@ -88,7 +88,7 @@ subroutine GetOutputSiteFraction(cSolnOut, iSublatticeOut, iConstituentOut, dSit
                 j = k
 
                 ! Verify that this solution phase has the correct
-	  	! phase type:
+                ! phase type:
                 if ((cSolnPhaseType(j) /= 'SUBLM').OR.(cSolnPhaseType(j) /= 'SUBL')) then
                     ! Do nothing.
                 else

--- a/src/InitGEMSolver.f90
+++ b/src/InitGEMSolver.f90
@@ -208,7 +208,7 @@ subroutine InitGEMSolver
                 do j = 1, nElements
                     dTemp = dTemp + dElementPotential(j) * dStoichSpecies(i,j)
                 end do
-                dTemp           = dTemp / DFLOAT(iParticlesPerMole(i))
+                dTemp           = dTemp / iParticlesPerMole(i)
                 dMolFraction(i) = DEXP(dTemp - dStdGibbsEnergy(i))
                 dMolFraction(i) = DMIN1(dMolFraction(i),1D0)
                 dSum            = dSum + dMolFraction(i)

--- a/src/KohlerInterpolate.f90
+++ b/src/KohlerInterpolate.f90
@@ -75,7 +75,7 @@ subroutine KohlerInterpolate(iSolnIndex,iParam,xT,dGParam,dPartialGParam)
     do i = 1, iRegularParam(iParam,1)
         j = nSpeciesPhase(iSolnIndex-1) + iRegularParam(iParam,i+1)
         dPartialExcessGibbs(j) = dPartialExcessGibbs(j) + (xT**(k-1)) * (dPartialGParam(i) + &
-            dGParam * (1D0 - xT) * (DFLOAT(k)-1D0))
+            dGParam * (1D0 - xT) * (k - 1D0))
     end do
 
     ! Compute the equivalent excess Gibbs energy of mixing of species that are not part of the sub-system:
@@ -84,7 +84,7 @@ subroutine KohlerInterpolate(iSolnIndex,iParam,xT,dGParam,dPartialGParam)
         do m = 1,k
             if (j == iRegularParam(iParam,m+1)) cycle LOOP_A
         end do
-        dPartialExcessGibbs(i) = dPartialExcessGibbs(i) - (xT**(k)) * (dGParam * (DFLOAT(k)-1D0))
+        dPartialExcessGibbs(i) = dPartialExcessGibbs(i) - (xT**(k)) * (dGParam * (k - 1D0))
     end do LOOP_A
     
     return

--- a/src/ParseCSDataBlock.f90
+++ b/src/ParseCSDataBlock.f90
@@ -220,7 +220,7 @@ subroutine ParseCSDataBlock
 
             case default
 
-                ! The solution phase type is not supported. Report an error.                                                                                                                              
+                ! The solution phase type is not supported. Report an error.
                 INFO = 17
                 return
                 

--- a/src/ParseCSDataBlockGibbs.f90
+++ b/src/ParseCSDataBlockGibbs.f90
@@ -147,7 +147,7 @@ subroutine ParseCSDataBlockGibbs(i,j,iCounterGibbsEqn)
     ! Note: ChemSage data-files store the stoichiometry coefficients as real variables, which may
     ! be less than one when there are more than 1 particles/mole.  I am going to convert the stoichiometry
     ! to an integer to minimize numerical error while still recording the number of particles per mole.
-    dTemp = DFLOAT(iParticlesPerMoleCS(j))
+    dTemp = iParticlesPerMoleCS(j)
     dStoichSpeciesCS(j,1:k) = dTempVec(1:k) * dTemp
 
     l = MOD(nElementsCS-10,11)

--- a/src/PolyRegularQKTO.f90
+++ b/src/PolyRegularQKTO.f90
@@ -89,7 +89,7 @@ subroutine PolyRegularQKTO(iSolnIndex,iParam,xT,dGParam,dPartialGParam)
     ! Compute the partial excess Gibbs energy of mixing per equivalent mole in the sub-system:
     do i = 1, iRegularParam(iParam,1)
         k = iRegularParam(iParam,iRegularParam(iParam,1) + 1 + i)
-        dPartialGParam(i) = dExcessGibbsParam(iParam) * (DFLOAT(k) * y(i)**(k - 1) + (1D0 - DFLOAT(zT)) * y(i)**k)
+        dPartialGParam(i) = dExcessGibbsParam(iParam) * (k * y(i)**(k - 1) + (1D0 - zT) * y(i)**k)
         
         ! Loop through parameters:
         do j = 1, iRegularParam(iParam,1)

--- a/src/PostLevelingSolver.f90
+++ b/src/PostLevelingSolver.f90
@@ -107,7 +107,7 @@ subroutine PostLevelingSolver
                 A(i,j) = dAtomFractionSpecies(iAssemblage(i),j)
             end do
             dLevel(j) = dChemicalPotential(iAssemblage(j))  + DLOG(dTempVecE(j)) / & 
-                !DFLOAT(iSpeciesTotalAtoms(iAssemblage(j)))
+                !iSpeciesTotalAtoms(iAssemblage(j))
                 dSpeciesTotalAtoms(iAssemblage(j))
         end do
                 

--- a/src/Subminimization.f90
+++ b/src/Subminimization.f90
@@ -276,7 +276,7 @@ subroutine SubMinInit(iSolnPhaseIndex,iterSubMax)
             dChemicalPotentialStar(k) = dChemicalPotentialStar(k) + dElementPotential(j) &
                 * dStoichSpecies(i,j)
         end do
-        dChemicalPotentialStar(k) = dChemicalPotentialStar(k) / DFLOAT(iParticlesPerMole(i))
+        dChemicalPotentialStar(k) = dChemicalPotentialStar(k) / iParticlesPerMole(i)
         
         ! Initialize the mole fractions:
         dMolFraction(i) = DMAX1(dMolFraction(i), 1D-15)
@@ -412,7 +412,7 @@ subroutine SubMinDrivingForce
     end do
     
     ! Normalize the driving force:
-    dDrivingForce = dDrivingForce / DFLOAT(nVar)
+    dDrivingForce = dDrivingForce / nVar
 
 end subroutine SubMinDrivingForce
 
@@ -780,7 +780,7 @@ subroutine SubMinCheckDuplicate(lDuplicate)
     end do
     
     ! Compute the normalized Euclidean norm between the mole fraction vectors between the two "phases":
-    dTemp = ( dTemp**(0.5) ) / DFLOAT(nVar)
+    dTemp = ( dTemp**(0.5) ) / nVar
     
     ! Check if the normalized Euclidean norm is less than a specified tolerance:
     if (dTemp < dTolEuclideanNorm) lDuplicate = .TRUE.

--- a/test/daily/TestThermo03.f90
+++ b/test/daily/TestThermo03.f90
@@ -53,7 +53,7 @@ program TestThermo03
     else
         ! The unit test failed.
         print *, 'TestThermo03: FAIL <---'
-        call EXIT(1)
+        error stop '1'
     end if
     
     ! Reset Thermochimica:

--- a/test/weekly/TestThermo101.f90
+++ b/test/weekly/TestThermo101.f90
@@ -71,11 +71,11 @@ program TestThermo101
         LOOP_B: do b = 1, 100, 1
 
             ! Define elemental masses:
-            dElementMass(1)  = DFLOAT(b) * 1D-3
+            dElementMass(1)  = (b) * 1D-3
             dElementMass(40) = 1D0 - dElementMass(1)
 
             ! Definte temperature:
-            dTemperature = DFLOAT(i)
+            dTemperature = (i)
 
             ! Call Thermochimica:
             call Thermochimica

--- a/test/weekly/TestThermo102.f90
+++ b/test/weekly/TestThermo102.f90
@@ -67,7 +67,7 @@ program TestThermo102
     LOOP_T: do i = 300, 1500, 1
 
         ! Definte temperature:
-        dTemperature = DFLOAT(i)
+        dTemperature = i
 
         ! Composition loop:
         LOOP_B: do b = 1, 100, 1


### PR DESCRIPTION
Fixes the following non-standard conforming issues:
- line count exceeding 132 characters
- tabs
- call to EXIT()
- DFLOAT